### PR TITLE
Initial Move Cannot Be Backwards

### DIFF
--- a/main.py
+++ b/main.py
@@ -8,8 +8,6 @@ from pygame import Vector2
 
 FPS = 60
 
-
-# TODO: Fix bug when snake's initial move is towards its tail.
 # TODO: End game using render_pos instead of cell position.
 
 def center(obj, parent_obj):
@@ -173,7 +171,8 @@ class Game:
                     extra_y = abs(render_pos.y - cell.y)
 
                     if render_pos.x < 0:
-                        self._draw_cell(Vector2(game.board_dimensions[0] - extra_x, cell.y), color)
+                        self._draw_cell(Vector2(game.board_dimensions[0] - extra_x, cell.y), color)The snake could go backwards eating itself at the start of the game,
+which causes the game to crash.
                     elif render_pos.x > game.board_dimensions[0] - 1:
                         self._draw_cell(Vector2(-1 + extra_x, cell.y), color)
                     elif render_pos.y < 0:

--- a/main.py
+++ b/main.py
@@ -188,6 +188,9 @@ class Game:
         def orient(self, orientation):
             # Make initial move
             if not self.was_moved:
+                if orientation == -self.current_orientation:
+                    return
+
                 self.current_orientation = orientation
                 self.was_moved = True
 
@@ -224,10 +227,6 @@ class Game:
                 self.current_orientation = self.next_orientations.popleft()
 
             return True, None
-
-        def make_initial_move(self, orientation):
-            self.current_orientation = orientation
-            self.was_moved = True
 
         def grow(self):
             self.body.appendleft(self.body[0].copy())


### PR DESCRIPTION
The snake could go backwards colliding with itself at the start of the game, which causes the game to crash. Now the snake, as any other moment in the game, does not queue a move in the same direction or the opposite direction.