### PR TITLE
Initial Move Cannot Be Backwards

### DIFF
--- a/main.py
+++ b/main.py
@@ -171,8 +171,7 @@ class Game:
                     extra_y = abs(render_pos.y - cell.y)
 
                     if render_pos.x < 0:
-                        self._draw_cell(Vector2(game.board_dimensions[0] - extra_x, cell.y), color)The snake could go backwards eating itself at the start of the game,
-which causes the game to crash.
+                        self._draw_cell(Vector2(game.board_dimensions[0] - extra_x, cell.y), color)
                     elif render_pos.x > game.board_dimensions[0] - 1:
                         self._draw_cell(Vector2(-1 + extra_x, cell.y), color)
                     elif render_pos.y < 0:


### PR DESCRIPTION
The snake could go backwards colliding with itself at the start of the game, which causes the game to crash. Now the snake, as any other moment in the game, does not queue a move in the same direction or the opposite direction.